### PR TITLE
handle failed OP_RETURN parsing

### DIFF
--- a/pkg/followerer/follower.go
+++ b/pkg/followerer/follower.go
@@ -165,7 +165,7 @@ func ParseOpReturnData(vout types.RawTxnVOut) []byte {
 	asm := vout.ScriptPubKey.Asm
 	parts := strings.Split(asm, " ")
 
-	if len(parts) > 0 {
+	if len(parts) > 1 {
 		op := parts[0]
 
 		if op == "OP_RETURN" {

--- a/pkg/followerer/follower_test.go
+++ b/pkg/followerer/follower_test.go
@@ -32,6 +32,49 @@ func (f *FakeChainFollower) Stop() {
 	close(f.Messages)
 }
 
+func TestParseOpReturnData(t *testing.T) {
+	t.Run("OP_RETURN with no payload does not panic", func(t *testing.T) {
+		vout := types.RawTxnVOut{
+			ScriptPubKey: types.RawTxnScriptPubKey{
+				Asm: "OP_RETURN",
+			},
+		}
+		result := followerer.ParseOpReturnData(vout)
+		assert.Equal(t, true, result == nil)
+	})
+
+	t.Run("OP_RETURN with valid hex payload returns bytes", func(t *testing.T) {
+		payload := []byte{0x01, 0x02, 0x03}
+		vout := types.RawTxnVOut{
+			ScriptPubKey: types.RawTxnScriptPubKey{
+				Asm: "OP_RETURN " + hex.EncodeToString(payload),
+			},
+		}
+		result := followerer.ParseOpReturnData(vout)
+		assert.DeepEqual(t, payload, result)
+	})
+
+	t.Run("non-OP_RETURN script returns nil", func(t *testing.T) {
+		vout := types.RawTxnVOut{
+			ScriptPubKey: types.RawTxnScriptPubKey{
+				Asm: "OP_DUP OP_HASH160 abc123 OP_EQUALVERIFY OP_CHECKSIG",
+			},
+		}
+		result := followerer.ParseOpReturnData(vout)
+		assert.Equal(t, true, result == nil)
+	})
+
+	t.Run("empty asm returns nil", func(t *testing.T) {
+		vout := types.RawTxnVOut{
+			ScriptPubKey: types.RawTxnScriptPubKey{
+				Asm: "",
+			},
+		}
+		result := followerer.ParseOpReturnData(vout)
+		assert.Equal(t, true, result == nil)
+	})
+}
+
 func TestDogeFollower(t *testing.T) {
 	tokenisationStore := test_support.SetupTestDB(t)
 	ctx := context.Background()


### PR DESCRIPTION
### Summary
 Fix index out of range panic in ParseOpReturnData when an OP_RETURN output has no data payload.

### Changes
  - pkg/followerer/follower.go: Changed guard in ParseOpReturnData from len(parts) > 0 to len(parts) > 1 before accessing parts[1]                                                                                                                   
  - pkg/followerer/follower_test.go: Added TestParseOpReturnData with four subtests covering the crash case and related edge cases
  - 
### Testing
  Added unit tests directly targeting ParseOpReturnData:
  - OP_RETURN with no payload (the crash case) — now returns nil without panicking
  - OP_RETURN with valid hex payload — verifies correct bytes are returned
  - Non-OP_RETURN script — returns nil
  - Empty ASM string — returns nil
  - 
### Checklist

  - Lint/format ran (make checks)
  - Tests added/updated
  - Docs updated
